### PR TITLE
Bugfixes + added #deregister(element, pseudo) to partially address issue #2

### DIFF
--- a/test/test.html
+++ b/test/test.html
@@ -1,38 +1,52 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <style>
-      #test {
+    <style type='text/css'>
+      .test {
         width: 100px;
         height: 100px;
+      }
+
+      #test1 {
         background: red;
       }
 
-      #test:hover {
+      #test1:hover {
         background: blue;
-        border: 2px solid red;
       }
 
-      .yellow:hover {
+      #test2 {
         background: yellow;
       }
 
-      #button {
+      .button {
         width: 100px;
+      }
+
+      #unused:hover, #test2:hover, #test2 > a:hover, div > span.unused:hover {
+        background: purple;
       }
     </style>
     <script src='../pseudostyler.js' type='text/javascript'></script>
   </head>
   <body>
-    <div id="test" class="yellow"></div>
-    <button id="button">Click</button>
+    <div>
+      <div id='test1' class='test'></div>
+      <button id='button1' class='button'>Click</button>
+    </div>
+    <div>
+      <div id='test2' class='test'></div>
+      <button id='button2' class='button'>Click</button>
+    </div>
     <script type='text/javascript'>
       (async () => {
         let styler = new PseudoStyler();
         await styler.loadDocumentStyles();
-        document.getElementById('button').addEventListener('click', () => {
-          const element = document.querySelector('#test');
-          styler.toggleStyle(element, ':hover');
+        document.querySelectorAll('.button').forEach(button => {
+          button.addEventListener('click', () => {
+            let tester = button.previousElementSibling;
+            styler.toggleStyle(tester, ':hover');
+          })
         })
       })();
     </script>


### PR DESCRIPTION
* Fixed multi-part selector handling.
* Added unique ids to distinguish between mimicked styles.
* Added #deregister to clear an element's mimicked pseudo class (useful if the style changes).
* Fixed rare css parse failure.
* Updated test with additional test cases.