### PR TITLE
Updated deregister to remove CSS rules.

### DIFF
--- a/pseudostyler.js
+++ b/pseudostyler.js
@@ -73,15 +73,24 @@ class PseudoStyler {
       this._createStyleElement();
     }
     for (let selector in customClasses) {
-      let _class = selector + ' { ' + customClasses[selector].join('') + ' }';
-      this.style.append(document.createTextNode(_class));
+      let cssClass = selector + ' { ' + customClasses[selector].join('') + ' }';
+      this.style.sheet.insertRule(cssClass)
     }
     this.registered.get(element).set(pseudoclass, uuid);
   }
 
   deregister(element, pseudoClass) {
     if (this.registered.has(element) && this.registered.get(element).has(pseudoClass)) {
+      let uuid = this.registered.get(element).get(pseudoClass);
+      let className = this._getMimicClassName(pseudoClass, uuid);
+      let regex = new RegExp(className + '($|\\W)');
+      for (let i = 0; i < this.style.sheet.cssRules.length; i++) {
+        if (regex.test(this.style.sheet.cssRules[i].selectorText)) {
+          this.style.sheet.deleteRule(i);
+        }
+      }
       this.registered.get(element).delete(pseudoClass);
+      element.classList.remove(className.substr(1));
     }
   }
 

--- a/test/test.html
+++ b/test/test.html
@@ -19,8 +19,9 @@
         background: yellow;
       }
 
-      .button {
+      .button, .remove {
         width: 100px;
+        display: block;
       }
 
       #unused:hover, #test2:hover, #test2 > a:hover, div > span.unused:hover {
@@ -32,11 +33,13 @@
   <body>
     <div>
       <div id='test1' class='test'></div>
-      <button id='button1' class='button'>Click</button>
+      <button class='button'>Click</button>
+      <button class='remove'>Destyle</button>
     </div>
     <div>
       <div id='test2' class='test'></div>
-      <button id='button2' class='button'>Click</button>
+      <button class='button'>Click</button>
+      <button class='remove'>Destyle</button>
     </div>
     <script type='text/javascript'>
       (async () => {
@@ -44,10 +47,16 @@
         await styler.loadDocumentStyles();
         document.querySelectorAll('.button').forEach(button => {
           button.addEventListener('click', () => {
-            let tester = button.previousElementSibling;
+            let tester = button.parentNode.firstElementChild;
             styler.toggleStyle(tester, ':hover');
-          })
-        })
+          });
+        });
+        document.querySelectorAll('.remove').forEach(button => {
+          button.addEventListener('click', () => {
+            let tester = button.parentNode.firstElementChild;
+            styler.deregister(tester, ':hover')
+          });
+        });
       })();
     </script>
   </body>


### PR DESCRIPTION
The inline `<style>` element no longer visibly updates to reflect its CSS rule contents, yet it still works correctly (seemingly).