### PR TITLE
Only store CSS rules with pseudo class selectors. Updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,43 @@ JSDelivr kindly hosts this script [here](https://www.jsdelivr.com/package/gh/TSe
 ### Explanation:
 This script will grab all of the stylesheets in the current document, obtain their href links, and pass the CSS sources into a hidden stylesheet to be parsed.
 
+### Methods:
+```javascript
+toggleStyle(element, pseudoClass)
+```
+
+Applies a pseudo class to an element.
+
+```javascript
+async loadDocumentStyles()
+```
+
+Asynchronously loads all styles from the current document to be parsed for pseudo class rules.
+
+```javascript
+register(element, pseudoClass)
+```
+
+Finds any applicable CSS pseudo class rules for the element and adds them to a separate style sheet. This method is called automatically by `toggleStyle`.
+
+```javascript
+deregister(element, pseudoClass)
+```
+
+Removes the element's mimicked pseudo class from the styler's stylesheet. This method can be useful to clear the mimicked rules in case the element's style has changed.
+
+```javascript
+addCSS(text)
+```
+
+Adds CSS to this style sheet's rules that are checked for pseudo classes.
+
+```javascript
+async addLink(url)
+```
+
+Fetches the CSS resource and adds its CSS to the styler.
+
 #### Thanks:
 
 Thanks goes to [Finn Thompson](https://github.com/FThompson) for the idea of the project and helping to polish the code and fix bugs for cross-browser compatibility.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![](https://data.jsdelivr.com/v1/package/gh/TSedlar/pseudo-styler/badge)](https://www.jsdelivr.com/package/gh/TSedlar/pseudo-styler)
 
-Allows for forcing an element to be styled with a pseudo-class
+Allows for forcing an element to be styled with a pseudo-class.
 
 ### Retrieving
 
@@ -27,14 +27,12 @@ JSDelivr kindly hosts this script [here](https://www.jsdelivr.com/package/gh/TSe
   document.getElementById('button').addEventListener('click', () => {
     const element = document.querySelector('#test');
     styler.toggleStyle(element, ':hover');
-  })
+  });
 })();
 ```
 
 ### Explanation:
-This script will grab all of the stylesheets in the current document, obtain their href links, and pass the CSS sources into a css parser.
-
-The default one should work fine, but can be overridden.
+This script will grab all of the stylesheets in the current document, obtain their href links, and pass the CSS sources into a hidden stylesheet to be parsed.
 
 #### Thanks:
 

--- a/pseudostyler.js
+++ b/pseudostyler.js
@@ -2,7 +2,7 @@ class PseudoStyler {
   constructor() {
     this.styles = [];
     this.registered = new WeakMap();
-    this.uniqueID = 0
+    this.uniqueID = 0;
   }
 
   async loadDocumentStyles() {
@@ -13,7 +13,7 @@ class PseudoStyler {
         await this.addLink(sheet.href);
       } else {
         if (sheet.ownerNode && sheet.ownerNode.nodeName &&
-            sheet.ownerNode.nodeName === "STYLE" && sheet.ownerNode.firstChild) {
+          sheet.ownerNode.nodeName === "STYLE" && sheet.ownerNode.firstChild) {
           this.addCSS(sheet.ownerNode.firstChild.textContent);
         }
       }
@@ -22,7 +22,7 @@ class PseudoStyler {
 
   addCSS(text) {
     let copySheet = document.createElement('style');
-    copySheet.type = 'text/css'
+    copySheet.type = 'text/css';
     copySheet.textContent = text;
     document.head.appendChild(copySheet);
     for (let i = 0; i < copySheet.sheet.cssRules.length; i++) {
@@ -30,16 +30,16 @@ class PseudoStyler {
         this.styles.push(copySheet.sheet.cssRules[i]);
       }
     }
-    document.head.removeChild(copySheet)
+    document.head.removeChild(copySheet);
   }
 
   async addLink(url) {
-  	const self = this;
-  	await new Promise((resolve, reject) => {
+    const self = this;
+    await new Promise((resolve, reject) => {
       fetch(url)
         .then(res => res.text())
         .then(res => {
-        	self.addCSS(res);
+          self.addCSS(res);
           resolve(self.styles);
         })
         .catch(err => reject(err));
@@ -52,11 +52,11 @@ class PseudoStyler {
     for (let style of this.styles) {
       if (style.selectorText.includes(pseudoclass)) {
         style.selectorText.split(/\s*,\s*/g)
-            .filter(selector => element.matches(selector.replace(new RegExp(pseudoclass, 'g'), '')))
-            .forEach(selector => {
-          let newSelector = this._getCustomSelector(selector, pseudoclass, uuid);
-          customClasses[newSelector] = style.style.cssText.split(/\s*;\s*/).map(rule => rule + ' !important').join(';');
-        })
+          .filter(selector => element.matches(selector.replace(new RegExp(pseudoclass, 'g'), '')))
+          .forEach(selector => {
+            let newSelector = this._getCustomSelector(selector, pseudoclass, uuid);
+            customClasses[newSelector] = style.style.cssText.split(/\s*;\s*/).map(rule => rule + ' !important').join(';');
+          });
       }
     }
 
@@ -65,7 +65,7 @@ class PseudoStyler {
     }
     for (let selector in customClasses) {
       let cssClass = selector + ' { ' + customClasses[selector] + ' }';
-      this.style.sheet.insertRule(cssClass)
+      this.style.sheet.insertRule(cssClass);
     }
     this.registered.get(element).set(pseudoclass, uuid);
   }

--- a/pseudostyler.js
+++ b/pseudostyler.js
@@ -26,7 +26,7 @@ class PseudoStyler {
     copySheet.textContent = text;
     document.head.appendChild(copySheet);
     for (let i = 0; i < copySheet.sheet.cssRules.length; i++) {
-      if (copySheet.sheet.cssRules[i].selectorText) {
+      if (copySheet.sheet.cssRules[i].selectorText && copySheet.sheet.cssRules[i].selectorText.includes(':')) {
         this.styles.push(copySheet.sheet.cssRules[i]);
       }
     }

--- a/test/test.html
+++ b/test/test.html
@@ -58,7 +58,7 @@
         document.querySelectorAll('.remove').forEach(button => {
           button.addEventListener('click', () => {
             let tester = button.parentNode.firstElementChild;
-            styler.deregister(tester, ':hover')
+            styler.deregister(tester, ':hover');
           });
         });
       })();


### PR DESCRIPTION
This change should save memory.

Updated README with all available methods.

Fixed some formatting.