### PR TITLE
Support for selectors where the pseudo style occurs in parent element

### DIFF
--- a/pseudostyler.js
+++ b/pseudostyler.js
@@ -48,10 +48,13 @@ class PseudoStyler {
 
   matches(element, selector, pseudoClass) {
     selector = selector.replace(new RegExp(pseudoClass, 'g'), '');
-    let compressed = selector.replace(/ *([^\w#:. ]) */g, '$1'); // remove extra spaces
-    for (let part of compressed.split(/ +/)) {
-      if (element.matches(part)) {
-        return true;
+    for (let part of selector.split(/ +/)) {
+      try {
+        if (element.matches(part)) {
+          return true;
+        }
+      } catch (ignored) {
+        // reached a non-selector part such as '>'
       }
     }
     return false;

--- a/pseudostyler.js
+++ b/pseudostyler.js
@@ -46,13 +46,24 @@ class PseudoStyler {
     });
   }
 
+  matches(element, selector, pseudoClass) {
+    selector = selector.replace(new RegExp(pseudoClass, 'g'), '');
+    let compressed = selector.replace(/ *([^\w#:. ]) */g, '$1'); // remove extra spaces
+    for (let part of compressed.split(/ +/)) {
+      if (element.matches(part)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   register(element, pseudoclass) {
     let uuid = this.uniqueID++;
     let customClasses = {};
     for (let style of this.styles) {
       if (style.selectorText.includes(pseudoclass)) {
         style.selectorText.split(/\s*,\s*/g)
-          .filter(selector => element.matches(selector.replace(new RegExp(pseudoclass, 'g'), '')))
+          .filter(selector => this.matches(element, selector, pseudoclass))
           .forEach(selector => {
             let newSelector = this._getCustomSelector(selector, pseudoclass, uuid);
             customClasses[newSelector] = style.style.cssText.split(/\s*;\s*/).map(rule => rule + ' !important').join(';');

--- a/test/test.html
+++ b/test/test.html
@@ -27,7 +27,7 @@
         background: orange;
       }
 
-      #child-test:hover .test {
+      #child-test:hover > .test {
         background: cyan;
       }
 

--- a/test/test.html
+++ b/test/test.html
@@ -19,6 +19,18 @@
         background: yellow;
       }
 
+      #child-test {
+        width: 100px;
+      }
+
+      #child-test .test {
+        background: orange;
+      }
+
+      #child-test:hover .test {
+        background: cyan;
+      }
+
       .button, .remove, .off {
         width: 100px;
         display: block;
@@ -43,6 +55,14 @@
     </div>
     <div>
       <div id='test2' class='test'></div>
+      <button class='button'>Toggle</button>
+      <button class='off'>Toggle off</button>
+      <button class='remove'>Deregister</button>
+    </div>
+    <div>
+      <a id='child-test'>
+        <div class='test'></div>
+      </a>
       <button class='button'>Toggle</button>
       <button class='off'>Toggle off</button>
       <button class='remove'>Deregister</button>


### PR DESCRIPTION
Support for selectors like the following.

```css
#parent:hover .child {
    /* rules */
}
```

Previously, selectors like this one were missed as they failed the `element.matches(selector)` check. My solution breaks down selectors into sub parts in order to check if any level of the selector hierarchy matches the target element.