### PR TITLE
Bugfix: Remove !important from pseudo styler rules.

### DIFF
--- a/pseudostyler.js
+++ b/pseudostyler.js
@@ -69,7 +69,7 @@ class PseudoStyler {
           .filter(selector => this.matches(element, selector, pseudoclass))
           .forEach(selector => {
             let newSelector = this._getCustomSelector(selector, pseudoclass, uuid);
-            customClasses[newSelector] = style.style.cssText.split(/\s*;\s*/).map(rule => rule + ' !important').join(';');
+            customClasses[newSelector] = style.style.cssText.split(/\s*;\s*/).join(';');
           });
       }
     }


### PR DESCRIPTION
Removed !important from inserted CSS rules to fix bug that occurred when multiple selectors applied competing style rules (e.g. two rules specifying different `backgroundColor` for the same element). Previously, the wrong style would sometimes be applied.